### PR TITLE
ci: add the sonarlint tool

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,77 @@
+---
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+    # For Branch-Protection check. Only the default branch is supported. See
+    # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+    branch_protection_rule:
+    # To guarantee Maintained check is occasionally updated. See
+    # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+    schedule:
+        - cron: '22 9 * * 3'
+    push:
+        branches: ["main"]
+# Declare default permissions as read only.
+permissions: read-all
+jobs:
+    analysis:
+        name: Scorecard analysis
+        runs-on: ubuntu-latest
+        permissions:
+            # Needed to upload the results to code-scanning dashboard.
+            security-events: write
+            # Needed to publish results and get a badge (see publish_results below).
+            id-token: write
+            # Uncomment the permissions below if installing in a private repository.
+            # contents: read
+            # actions: read
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+              with:
+                egress-policy: audit
+            - name: "Checkout code"
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              with:
+                persist-credentials: false
+            - name: "Run analysis"
+              uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+              with:
+                results_file: results.sarif
+                results_format: sarif
+                # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+                # - you want to enable the Branch-Protection check on a *public* repository, or
+                # - you are installing Scorecard on a *private* repository
+                # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+                # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+                # Public repositories:
+                #   - Publish results to OpenSSF REST API for easy access by consumers
+                #   - Allows the repository to include the Scorecard badge.
+                #   - See https://github.com/ossf/scorecard-action#publishing-results.
+                # For private repositories:
+                #   - `publish_results` will always be set to `false`, regardless
+                #     of the value entered here.
+                publish_results: true
+            # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+            # format to the repository Actions tab.
+            - name: "Upload artifact"
+              uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.pre.node20
+              with:
+                name: SARIF file
+                path: results.sarif
+                retention-days: 5
+            # Upload the results to GitHub's code scanning dashboard (optional).
+            # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+            - name: "Upload to code-scanning"
+              uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3
+              with:
+                sarif_file: results.sarif


### PR DESCRIPTION
### TL;DR
Added OSSF Scorecard GitHub Action workflow for supply chain security analysis

### What changed?
- Introduced a new GitHub Actions workflow for OSSF Scorecard
- Configured workflow to run on schedule (Wednesdays at 9:22 UTC)
- Set up security scanning with branch protection rules
- Implemented artifact uploading and code scanning results integration
- Added support for both public and private repository configurations

### How to test?
1. Merge this PR to main branch
2. Check the Actions tab for the "Scorecard supply-chain security" workflow
3. Verify that SARIF results are uploaded to code scanning dashboard
4. Confirm security events are being properly logged
5. Check that the scorecard badge is generated (for public repositories)

### Why make this change?
To enhance the repository's supply chain security by implementing automated security scanning and monitoring. This helps identify potential vulnerabilities, maintains security best practices, and provides transparency through automated security scoring.