### PR TITLE
ci: harden the CI workflows

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,9 +1,8 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 name: Security Audit
 on:
     schedule:
@@ -20,10 +19,14 @@ jobs:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
         runs-on: ubuntu-latest
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install Rust
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@4f647fc679bcd3b11499ccb42104547c83dabe96 # stable
             - name: Install cargo-audit
               uses: taiki-e/install-action@2b51c05cf7315a16dcec651726da87c70e45b990 # v2.45.7
               with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,8 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 name: Continuous integration
 on:
     push:
@@ -21,33 +20,36 @@ env:
     RUST_BACKTRACE: 1
     MINIMUM_WAIT: 3
     MAXIMUM_WAIT: 10
-
 permissions:
-  id-token: write
-  attestations: write
+    id-token: write
+    attestations: write
 jobs:
     check_changed_dirs:
-      runs-on: ubuntu-latest
-      outputs:
-        source_changed: ${{steps.changed_dirs.outputs.source}}
-        book_changed: ${{steps.changed_dirs.outputs.book}}
-      steps:
-        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        - name: Check changed directories
-          id: changed_dirs
-          uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-          with:
-            base: ${{ github.ref }}
-            filters: |
-              source:
-                - "src/**/*"
-                - "tests/**/*"
-                - "examples/**/*"
-                - "Cargo.toml"
-                - "Cargo.lock"
-              book:
-                - "guide/src/*.md"
-                - "guide/book.toml"
+        runs-on: ubuntu-latest
+        outputs:
+            source_changed: ${{steps.changed_dirs.outputs.source}}
+            book_changed: ${{steps.changed_dirs.outputs.book}}
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - name: Check changed directories
+              id: changed_dirs
+              uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+              with:
+                base: ${{ github.ref }}
+                filters: |
+                    source:
+                      - "src/**/*"
+                      - "tests/**/*"
+                      - "examples/**/*"
+                      - "Cargo.toml"
+                      - "Cargo.lock"
+                    book:
+                      - "guide/src/*.md"
+                      - "guide/book.toml"
     ci:
         runs-on: ${{matrix.os}}-latest
         needs: [check_changed_dirs]
@@ -82,16 +84,20 @@ jobs:
                     - rust: nightly
                       label: nightly
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install Rust
               if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@master
+              uses: dtolnay/rust-toolchain@315e265cd78dad1e1dcf3a5074f6d6c47029d5aa # master
               with:
                 toolchain: ${{matrix.rust}}
                 components: rustfmt, clippy
             - name: Install nightly Rust
               if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@nightly
+              uses: dtolnay/rust-toolchain@525fbff0dae0f21267554d5c96520a169909e20a # nightly
               with:
                 toolchain: nightly
                 components: rustfmt, clippy

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,9 +1,8 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 name: Code Coverage
 on:
     workflow_call:
@@ -15,10 +14,14 @@ jobs:
             image: xd009642/tarpaulin:develop-nightly@sha256:7f0d65f160c70f5f94bc9dd6dbb2150bf080eaddbc9adaa3893d3aa85f3e4ebc
             options: --security-opt seccomp=unconfined
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout repository
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             # Nightly Rust is required for cargo llvm-cov --doc.
-            - uses: dtolnay/rust-toolchain@nightly
+            - uses: dtolnay/rust-toolchain@525fbff0dae0f21267554d5c96520a169909e20a # nightly
               with:
                 components: llvm-tools-preview
             - uses: taiki-e/install-action@2b51c05cf7315a16dcec651726da87c70e45b990 # v2.45.7

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,30 @@
+---
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+permissions:
+    contents: read
+jobs:
+    dependency-review:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
+            - name: 'Checkout Repository'
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - name: 'Dependency Review'
+              uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -1,9 +1,8 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 name: Next semantic-release version
 on:
     workflow_call:
@@ -11,6 +10,8 @@ on:
             new-release-published:
                 description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
                 value: ${{ jobs.get-next-version.outputs.new-release-published }}
+permissions:
+    contents: read
 jobs:
     get-next-version:
         name: Get next release version
@@ -18,6 +19,10 @@ jobs:
         outputs:
             new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,10 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 on:
     workflow_call:
-
 name: Semantic Release
 env:
     RUST_BACKTRACE: 1
@@ -47,6 +45,10 @@ jobs:
                       target: i686-pc-windows-gnu
                       cross: true
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install tree
@@ -56,7 +58,7 @@ jobs:
               if: runner.os == 'Linux' && !matrix.build.cross
               run: sudo apt install musl-tools mingw-w64
             - name: Install Rust toolchain
-              uses: dtolnay/rust-toolchain@master
+              uses: dtolnay/rust-toolchain@315e265cd78dad1e1dcf3a5074f6d6c47029d5aa # master
               id: rust-toolchain
               with:
                 toolchain: stable
@@ -98,14 +100,18 @@ jobs:
         runs-on: ubuntu-latest
         needs: build_application
         permissions:
-          id-token: write
-          attestations: write
+            id-token: write
+            attestations: write
         outputs:
             new_release_version: ${{steps.semantic.outputs.new_release_version}}
             new_release_published: ${{steps.semantic.outputs.new_release_published}}
             new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
             new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
@@ -144,8 +150,8 @@ jobs:
               uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
               with:
                 subject-path: |
-                  dist/gh-bofh*
-                  !dist/*.asc
+                    dist/gh-bofh*
+                    !dist/*.asc
             - name: Move attestation to dist
               run: mv ${{steps.attestation.outputs.bundle-path}} dist/attestation.jsonl
             - name: Semantic Release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,3 +135,7 @@ repos:
       rev: v4.0.2
       hooks:
         - id: reuse
+    - repo: https://github.com/jumanjihouse/pre-commit-hooks
+      rev: 3.0.0
+      hooks:
+        - id: shellcheck


### PR DESCRIPTION
### TL;DR
Added security hardening to GitHub Actions workflows and pinned action versions.

### What changed?
- Added step-security/harden-runner to all GitHub Actions workflows
- Added new dependency-review workflow for scanning dependency manifest files
- Pinned all GitHub Action versions with SHA hashes
- Added shellcheck pre-commit hook
- Reorganized YAML file structures for consistency
- Added explicit permissions to workflows

### How to test?
1. Verify all GitHub Actions workflows run successfully
2. Check that dependency review runs on pull requests
3. Validate pre-commit hooks execute with shellcheck
4. Confirm security scanning and attestations work as expected

### Why make this change?
To enhance security posture by:
- Preventing supply chain attacks through action version pinning
- Adding automated dependency vulnerability scanning
- Implementing runner hardening to control egress traffic
- Enforcing shell script quality through shellcheck
- Following security best practices for GitHub Actions