### PR TITLE
build: added clarification for rustix and linux-raw-sys crates

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,9 +1,8 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 name: Security Audit
 on:
     schedule:
@@ -20,10 +19,14 @@ jobs:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
         runs-on: ubuntu-latest
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install Rust
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@4f647fc679bcd3b11499ccb42104547c83dabe96 # stable
             - name: Install cargo-audit
               uses: taiki-e/install-action@2b51c05cf7315a16dcec651726da87c70e45b990 # v2.45.7
               with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,8 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 name: Continuous integration
 on:
     push:
@@ -21,33 +20,36 @@ env:
     RUST_BACKTRACE: 1
     MINIMUM_WAIT: 3
     MAXIMUM_WAIT: 10
-
 permissions:
-  id-token: write
-  attestations: write
+    id-token: write
+    attestations: write
 jobs:
     check_changed_dirs:
-      runs-on: ubuntu-latest
-      outputs:
-        source_changed: ${{steps.changed_dirs.outputs.source}}
-        book_changed: ${{steps.changed_dirs.outputs.book}}
-      steps:
-        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        - name: Check changed directories
-          id: changed_dirs
-          uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-          with:
-            base: ${{ github.ref }}
-            filters: |
-              source:
-                - "src/**/*"
-                - "tests/**/*"
-                - "examples/**/*"
-                - "Cargo.toml"
-                - "Cargo.lock"
-              book:
-                - "guide/src/*.md"
-                - "guide/book.toml"
+        runs-on: ubuntu-latest
+        outputs:
+            source_changed: ${{steps.changed_dirs.outputs.source}}
+            book_changed: ${{steps.changed_dirs.outputs.book}}
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - name: Check changed directories
+              id: changed_dirs
+              uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+              with:
+                base: ${{ github.ref }}
+                filters: |
+                    source:
+                      - "src/**/*"
+                      - "tests/**/*"
+                      - "examples/**/*"
+                      - "Cargo.toml"
+                      - "Cargo.lock"
+                    book:
+                      - "guide/src/*.md"
+                      - "guide/book.toml"
     ci:
         runs-on: ${{matrix.os}}-latest
         needs: [check_changed_dirs]
@@ -82,16 +84,20 @@ jobs:
                     - rust: nightly
                       label: nightly
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install Rust
               if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@master
+              uses: dtolnay/rust-toolchain@315e265cd78dad1e1dcf3a5074f6d6c47029d5aa # master
               with:
                 toolchain: ${{matrix.rust}}
                 components: rustfmt, clippy
             - name: Install nightly Rust
               if: ${{ needs.check_changed_dirs.outputs.source_changed == 'true' }}
-              uses: dtolnay/rust-toolchain@nightly
+              uses: dtolnay/rust-toolchain@525fbff0dae0f21267554d5c96520a169909e20a # nightly
               with:
                 toolchain: nightly
                 components: rustfmt, clippy

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,9 +1,8 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 name: Code Coverage
 on:
     workflow_call:
@@ -15,10 +14,14 @@ jobs:
             image: xd009642/tarpaulin:develop-nightly@sha256:7f0d65f160c70f5f94bc9dd6dbb2150bf080eaddbc9adaa3893d3aa85f3e4ebc
             options: --security-opt seccomp=unconfined
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout repository
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             # Nightly Rust is required for cargo llvm-cov --doc.
-            - uses: dtolnay/rust-toolchain@nightly
+            - uses: dtolnay/rust-toolchain@525fbff0dae0f21267554d5c96520a169909e20a # nightly
               with:
                 components: llvm-tools-preview
             - uses: taiki-e/install-action@2b51c05cf7315a16dcec651726da87c70e45b990 # v2.45.7

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,30 @@
+---
+# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
+
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+permissions:
+    contents: read
+jobs:
+    dependency-review:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
+            - name: 'Checkout Repository'
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - name: 'Dependency Review'
+              uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -1,9 +1,8 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 name: Next semantic-release version
 on:
     workflow_call:
@@ -11,6 +10,8 @@ on:
             new-release-published:
                 description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
                 value: ${{ jobs.get-next-version.outputs.new-release-published }}
+permissions:
+    contents: read
 jobs:
     get-next-version:
         name: Get next release version
@@ -18,6 +19,10 @@ jobs:
         outputs:
             new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,10 @@
+---
 # SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
-
----
 on:
     workflow_call:
-
 name: Semantic Release
 env:
     RUST_BACKTRACE: 1
@@ -47,6 +45,10 @@ jobs:
                       target: i686-pc-windows-gnu
                       cross: true
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - name: Install tree
@@ -56,7 +58,7 @@ jobs:
               if: runner.os == 'Linux' && !matrix.build.cross
               run: sudo apt install musl-tools mingw-w64
             - name: Install Rust toolchain
-              uses: dtolnay/rust-toolchain@master
+              uses: dtolnay/rust-toolchain@315e265cd78dad1e1dcf3a5074f6d6c47029d5aa # master
               id: rust-toolchain
               with:
                 toolchain: stable
@@ -98,14 +100,18 @@ jobs:
         runs-on: ubuntu-latest
         needs: build_application
         permissions:
-          id-token: write
-          attestations: write
+            id-token: write
+            attestations: write
         outputs:
             new_release_version: ${{steps.semantic.outputs.new_release_version}}
             new_release_published: ${{steps.semantic.outputs.new_release_published}}
             new_release_notes: ${{steps.semantic.outputs.new_release_notes}}
             new_release_channel: ${{steps.semantic.outputs.new_release_channel}}
         steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+              with:
+                egress-policy: audit
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
@@ -144,8 +150,8 @@ jobs:
               uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
               with:
                 subject-path: |
-                  dist/gh-bofh*
-                  !dist/*.asc
+                    dist/gh-bofh*
+                    !dist/*.asc
             - name: Move attestation to dist
               run: mv ${{steps.attestation.outputs.bundle-path}} dist/attestation.jsonl
             - name: Semantic Release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,3 +135,7 @@ repos:
       rev: v4.0.2
       hooks:
         - id: reuse
+    - repo: https://github.com/jumanjihouse/pre-commit-hooks
+      rev: 3.0.0
+      hooks:
+        - id: shellcheck

--- a/about.toml
+++ b/about.toml
@@ -6,16 +6,16 @@
 # Accepted licesnes by default
 accepted = ["Apache-2.0", "MIT"]
 targets = [
-    "aarch64-apple-darwin",
-    "aarch64-unknown-linux-gnu",
-    "aarch64-unknown-linux-musl",
-    "i686-unknown-linux-gnu",
-    "i686-unknown-linux-musl",
-    "x86_64-apple-darwin",
-    "x86_64-unknown-linux-gnu",
-    "x86_64-unknown-linux-musl",
-    "x86_64-pc-windows-gnu",
-    "i686-pc-windows-gnu",
+  "aarch64-apple-darwin",
+  "aarch64-unknown-linux-gnu",
+  "aarch64-unknown-linux-musl",
+  "i686-unknown-linux-gnu",
+  "i686-unknown-linux-musl",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+  "x86_64-pc-windows-gnu",
+  "i686-pc-windows-gnu",
 ]
 
 # Do not ignore any dependencies
@@ -70,67 +70,42 @@ accepted = ["CC0-1.0"]
 [unicode-ident]
 accepted = ["Unicode-DFS-2016"]
 
-# Specify the license for `stability`
-# MIT: https://github.com/sagebind/stability
-[stability.clarify]
-license = "MIT"
+[rustix.clarify]
+license = "Apache-2.0 OR (Apache-2.0 WITH LLVM-exception) OR MIT"
 
-[[stability.clarify.git]]
-path = "LICENSE"
-checksum = "1c53c5a23d1bcc3df0ba1bdb8079421331c344e082d70b7fbb8ee5461d76a24c" #pragma: allowlist secret
-
-# Specify the license for `proc-macro2`
-# MIT: https://github.com/dtolnay/proc-macro2/LICENSE-MIT
-# Apache-2.0: https://github.com/dtolnay/proc-macro2/LICENSE-APACHE
-[proc-macro2.clarify]
-license = "MIT OR Apache-2.0"
-
-[[proc-macro2.clarify.git]]
-path = "LICENSE-MIT"
-license = "MIT"
-checksum = "23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3" #pragma: allowlist secret
-
-[[proc-macro2.clarify.git]]
+[[rustix.clarify.git]]
 path = "LICENSE-APACHE"
 license = "Apache-2.0"
-checksum = "62c7a1e35f56406896d7aa7ca52d0cc0d272ac022b5d2796e7d6905db8a3636a" #pragma: allowlist secret
+checksum = "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2" # pragma: allowlist secret
 
-# Specify the license for `anyhow`
-# MIT: https://github.com/dtolnay/anyhow/LICENSE-MIT
-# Apache-2.0: https://github.com/dtolnay/anyhow/LICENSE-APACHE
-[anyhow.clarify]
-license = "MIT OR Apache-2.0"
+[[rustix.clarify.git]]
+path = "LICENSE-Apache-2.0_WITH_LLVM-exception"
+license = "Apache-2.0 WITH LLVM-exception"
+checksum = "268872b9816f90fd8e85db5a28d33f8150ebb8dd016653fb39ef1f94f2686bc5" # pragma: allowlist secret
 
-[[anyhow.clarify.git]]
+
+[[rustix.clarify.git]]
 path = "LICENSE-MIT"
 license = "MIT"
-checksum = "23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3" #pragma: allowlist secret
+checksum = "23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3" # pragma: allowlist secret
 
-[[anyhow.clarify.git]]
+
+[linux-raw-sys.clarify]
+license = "Apache-2.0 OR (Apache-2.0 WITH LLVM-exception) OR MIT"
+
+[[linux-raw-sys.clarify.git]]
 path = "LICENSE-APACHE"
 license = "Apache-2.0"
-checksum = "62c7a1e35f56406896d7aa7ca52d0cc0d272ac022b5d2796e7d6905db8a3636a" #pragma: allowlist secret
-
-# Specify the license for `ratatui`
-# MIT: https://github.com/ratatui-org/ratatui
-[ratatui.clarify]
-license = "MIT"
-
-[[ratatui.clarify.git]]
-path = "LICENSE"
-checksum = "2b18886c930206292980646fa5d0b80c076be55516a93fbcb1bc4fe1a849f76c" #pragma: allowlist secret
+checksum = "a60eea817514531668d7e00765731449fe14d059d3249e0bc93b36de45f759f2" # pragma: allowlist secret
 
 
-# Specify the license for `document-features`
-[document-features.clarify]
-license = "MIT OR Apache-2.0"
+[[linux-raw-sys.clarify.git]]
+path = "LICENSE-Apache-2.0_WITH_LLVM-exception"
+license = "Apache-2.0 WITH LLVM-exception"
+checksum = "268872b9816f90fd8e85db5a28d33f8150ebb8dd016653fb39ef1f94f2686bc5" # pragma: allowlist secret
 
-[[document-features.clarify.git]]
+
+[[linux-raw-sys.clarify.git]]
 path = "LICENSE-MIT"
 license = "MIT"
-checksum = "aa893340d14b9844625be6a50ac644169a01b52f0211cbf81b09e1874c8cd81d" #pragma: allowlist secret
-
-[[document-features.clarify.git]]
-path = "LICENSE-APACHE"
-license = "Apache-2.0"
-checksum = "074e6e32c86a4c0ef8b3ed25b721ca23aca83df277cd88106ef7177c354615ff" #pragma: allowlist secret
+checksum = "23f18e03dc49df91622fe2a76176497404e46ced8a715d9d2b67a7446571cca3" # pragma: allowlist secret

--- a/licenses_report.json
+++ b/licenses_report.json
@@ -1689,7 +1689,7 @@
                         "path": null,
                         "registry": null,
                         "rename": null,
-                        "req": "=4.5.20",
+                        "req": "=4.5.21",
                         "source": "registry+https://github.com/rust-lang/crates.io-index",
                         "target": null,
                         "uses_default_features": false
@@ -1890,7 +1890,7 @@
                     ]
                 },
                 "homepage": null,
-                "id": "registry+https://github.com/rust-lang/crates.io-index#clap@4.5.20",
+                "id": "registry+https://github.com/rust-lang/crates.io-index#clap@4.5.21",
                 "keywords": [
                     "argument",
                     "cli",
@@ -1901,14 +1901,10 @@
                 "license": "MIT OR Apache-2.0",
                 "license_file": null,
                 "links": null,
-                "manifest_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/Cargo.toml",
+                "manifest_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/Cargo.toml",
                 "metadata": {
                     "docs": {
                         "rs": {
-                            "cargo-args": [
-                                "-Zunstable-options",
-                                "-Zrustdoc-scrape-examples"
-                            ],
                             "features": [
                                 "unstable-doc"
                             ],
@@ -1996,7 +1992,7 @@
                         ],
                         "name": "clap",
                         "required-features": [],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/src/lib.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/src/lib.rs",
                         "test": true
                     },
                     {
@@ -2011,7 +2007,7 @@
                         ],
                         "name": "stdio-fixture",
                         "required-features": [],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/src/bin/stdio-fixture.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/src/bin/stdio-fixture.rs",
                         "test": true
                     },
                     {
@@ -2028,7 +2024,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/01_quick.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/01_quick.rs",
                         "test": false
                     },
                     {
@@ -2045,7 +2041,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/01_quick.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/01_quick.rs",
                         "test": false
                     },
                     {
@@ -2062,7 +2058,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/02_app_settings.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/02_app_settings.rs",
                         "test": false
                     },
                     {
@@ -2079,7 +2075,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/02_app_settings.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/02_app_settings.rs",
                         "test": false
                     },
                     {
@@ -2094,7 +2090,7 @@
                         ],
                         "name": "02_apps",
                         "required-features": [],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/02_apps.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/02_apps.rs",
                         "test": false
                     },
                     {
@@ -2111,7 +2107,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/02_apps.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/02_apps.rs",
                         "test": false
                     },
                     {
@@ -2128,7 +2124,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/02_crate.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/02_crate.rs",
                         "test": false
                     },
                     {
@@ -2145,7 +2141,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/02_crate.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/02_crate.rs",
                         "test": false
                     },
                     {
@@ -2162,7 +2158,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_01_flag_bool.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_01_flag_bool.rs",
                         "test": false
                     },
                     {
@@ -2179,7 +2175,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_01_flag_bool.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_01_flag_bool.rs",
                         "test": false
                     },
                     {
@@ -2196,7 +2192,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_01_flag_count.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_01_flag_count.rs",
                         "test": false
                     },
                     {
@@ -2213,7 +2209,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_01_flag_count.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_01_flag_count.rs",
                         "test": false
                     },
                     {
@@ -2230,7 +2226,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_02_option.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_02_option.rs",
                         "test": false
                     },
                     {
@@ -2247,7 +2243,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_02_option.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_02_option.rs",
                         "test": false
                     },
                     {
@@ -2264,7 +2260,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_02_option_mult.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_02_option_mult.rs",
                         "test": false
                     },
                     {
@@ -2281,7 +2277,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_02_option_mult.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_02_option_mult.rs",
                         "test": false
                     },
                     {
@@ -2298,7 +2294,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_03_positional.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_03_positional.rs",
                         "test": false
                     },
                     {
@@ -2315,7 +2311,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_03_positional.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_03_positional.rs",
                         "test": false
                     },
                     {
@@ -2332,7 +2328,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_03_positional_mult.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_03_positional_mult.rs",
                         "test": false
                     },
                     {
@@ -2349,7 +2345,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_03_positional_mult.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_03_positional_mult.rs",
                         "test": false
                     },
                     {
@@ -2366,7 +2362,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_04_subcommands.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_04_subcommands.rs",
                         "test": false
                     },
                     {
@@ -2383,7 +2379,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_04_subcommands_alt.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_04_subcommands_alt.rs",
                         "test": false
                     },
                     {
@@ -2400,7 +2396,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_04_subcommands.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_04_subcommands.rs",
                         "test": false
                     },
                     {
@@ -2417,7 +2413,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_05_default_values.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_05_default_values.rs",
                         "test": false
                     },
                     {
@@ -2434,7 +2430,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_05_default_values.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_05_default_values.rs",
                         "test": false
                     },
                     {
@@ -2451,7 +2447,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_01_enum.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_01_enum.rs",
                         "test": false
                     },
                     {
@@ -2468,7 +2464,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_01_enum.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_01_enum.rs",
                         "test": false
                     },
                     {
@@ -2485,7 +2481,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_01_possible.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_01_possible.rs",
                         "test": false
                     },
                     {
@@ -2502,7 +2498,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_02_parse.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_02_parse.rs",
                         "test": false
                     },
                     {
@@ -2519,7 +2515,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_02_parse.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_02_parse.rs",
                         "test": false
                     },
                     {
@@ -2536,7 +2532,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_02_validate.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_02_validate.rs",
                         "test": false
                     },
                     {
@@ -2553,7 +2549,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_02_validate.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_02_validate.rs",
                         "test": false
                     },
                     {
@@ -2570,7 +2566,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_03_relations.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_03_relations.rs",
                         "test": false
                     },
                     {
@@ -2587,7 +2583,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_03_relations.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_03_relations.rs",
                         "test": false
                     },
                     {
@@ -2604,7 +2600,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_04_custom.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_04_custom.rs",
                         "test": false
                     },
                     {
@@ -2621,7 +2617,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_04_custom.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_04_custom.rs",
                         "test": false
                     },
                     {
@@ -2638,7 +2634,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/05_01_assert.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/05_01_assert.rs",
                         "test": true
                     },
                     {
@@ -2655,7 +2651,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/05_01_assert.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/05_01_assert.rs",
                         "test": true
                     },
                     {
@@ -2670,7 +2666,7 @@
                         ],
                         "name": "busybox",
                         "required-features": [],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/multicall-busybox.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/multicall-busybox.rs",
                         "test": false
                     },
                     {
@@ -2688,7 +2684,7 @@
                             "cargo",
                             "color"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/cargo-example.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/cargo-example.rs",
                         "test": false
                     },
                     {
@@ -2706,7 +2702,7 @@
                             "derive",
                             "color"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/cargo-example-derive.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/cargo-example-derive.rs",
                         "test": false
                     },
                     {
@@ -2723,7 +2719,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/demo.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/demo.rs",
                         "test": false
                     },
                     {
@@ -2740,7 +2736,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/escaped-positional.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/escaped-positional.rs",
                         "test": false
                     },
                     {
@@ -2757,7 +2753,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/escaped-positional-derive.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/escaped-positional-derive.rs",
                         "test": false
                     },
                     {
@@ -2774,7 +2770,7 @@
                         "required-features": [
                             "cargo"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/find.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/find.rs",
                         "test": false
                     },
                     {
@@ -2789,7 +2785,7 @@
                         ],
                         "name": "git",
                         "required-features": [],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/git.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/git.rs",
                         "test": false
                     },
                     {
@@ -2806,7 +2802,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/git-derive.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/git-derive.rs",
                         "test": false
                     },
                     {
@@ -2821,7 +2817,7 @@
                         ],
                         "name": "hostname",
                         "required-features": [],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/multicall-hostname.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/multicall-hostname.rs",
                         "test": false
                     },
                     {
@@ -2838,7 +2834,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/derive_ref/augment_args.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/derive_ref/augment_args.rs",
                         "test": false
                     },
                     {
@@ -2855,7 +2851,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/derive_ref/augment_subcommands.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/derive_ref/augment_subcommands.rs",
                         "test": false
                     },
                     {
@@ -2872,7 +2868,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/derive_ref/flatten_hand_args.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/derive_ref/flatten_hand_args.rs",
                         "test": false
                     },
                     {
@@ -2889,7 +2885,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/derive_ref/hand_subcommand.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/derive_ref/hand_subcommand.rs",
                         "test": false
                     },
                     {
@@ -2904,7 +2900,7 @@
                         ],
                         "name": "pacman",
                         "required-features": [],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/pacman.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/pacman.rs",
                         "test": false
                     },
                     {
@@ -2921,7 +2917,7 @@
                         "required-features": [
                             "help"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/repl.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/repl.rs",
                         "test": false
                     },
                     {
@@ -2938,7 +2934,7 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/repl-derive.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/repl-derive.rs",
                         "test": false
                     },
                     {
@@ -2955,11 +2951,11 @@
                         "required-features": [
                             "derive"
                         ],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/typed-derive.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/typed-derive.rs",
                         "test": false
                     }
                 ],
-                "version": "4.5.20"
+                "version": "4.5.21"
             }
         },
         {
@@ -3172,7 +3168,7 @@
                     ]
                 },
                 "homepage": null,
-                "id": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.20",
+                "id": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.21",
                 "keywords": [
                     "argument",
                     "cli",
@@ -3183,7 +3179,7 @@
                 "license": "MIT OR Apache-2.0",
                 "license_file": null,
                 "links": null,
-                "manifest_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.20/Cargo.toml",
+                "manifest_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.21/Cargo.toml",
                 "metadata": {
                     "docs": {
                         "rs": {
@@ -3230,11 +3226,11 @@
                         ],
                         "name": "clap_builder",
                         "required-features": [],
-                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.20/src/lib.rs",
+                        "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.21/src/lib.rs",
                         "test": true
                     }
                 ],
-                "version": "4.5.20"
+                "version": "4.5.21"
             }
         },
         {
@@ -6761,7 +6757,7 @@
                 "edition": "2021",
                 "features": {},
                 "homepage": null,
-                "id": "path+file:///Users/aimami/experiments/rust-projects/gh-bofh-rs#1.2.0",
+                "id": "path+file:///Users/aimami/experiments/rust-projects/gh-bofh-rs#1.2.1-next.1",
                 "keywords": [],
                 "license": "MIT OR Apache-2.0",
                 "license_file": null,
@@ -6805,7 +6801,7 @@
                         "test": true
                     }
                 ],
-                "version": "1.2.0"
+                "version": "1.2.1-next.1"
             }
         },
         {
@@ -8048,7 +8044,7 @@
             }
         },
         {
-            "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+            "license": "Apache-2.0 OR (Apache-2.0 WITH LLVM-exception) OR MIT",
             "package": {
                 "authors": [
                     "Dan Gohman <dev@sunfishcode.online>"
@@ -11555,7 +11551,7 @@
             }
         },
         {
-            "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT",
+            "license": "Apache-2.0 OR (Apache-2.0 WITH LLVM-exception) OR MIT",
             "package": {
                 "authors": [
                     "Dan Gohman <dev@sunfishcode.online>",
@@ -19208,7 +19204,7 @@
                             ]
                         },
                         "homepage": null,
-                        "id": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.20",
+                        "id": "registry+https://github.com/rust-lang/crates.io-index#clap_builder@4.5.21",
                         "keywords": [
                             "argument",
                             "cli",
@@ -19219,7 +19215,7 @@
                         "license": "MIT OR Apache-2.0",
                         "license_file": null,
                         "links": null,
-                        "manifest_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.20/Cargo.toml",
+                        "manifest_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.21/Cargo.toml",
                         "metadata": {
                             "docs": {
                                 "rs": {
@@ -19266,11 +19262,11 @@
                                 ],
                                 "name": "clap_builder",
                                 "required-features": [],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.20/src/lib.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.21/src/lib.rs",
                                 "test": true
                             }
                         ],
-                        "version": "4.5.20"
+                        "version": "4.5.21"
                     },
                     "path": null
                 },
@@ -19507,7 +19503,7 @@
             "first_of_kind": false,
             "id": "Apache-2.0",
             "name": "Apache License 2.0",
-            "source_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anstyle-parse-0.2.3/LICENSE-APACHE",
+            "source_path": "LICENSE-APACHE",
             "text": "                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"{}\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright {yyyy} {name of copyright owner}\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n",
             "used_by": [
                 {
@@ -19737,7 +19733,7 @@
             "first_of_kind": false,
             "id": "Apache-2.0",
             "name": "Apache License 2.0",
-            "source_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anstream-0.6.8/LICENSE-APACHE",
+            "source_path": "LICENSE-APACHE",
             "text": "                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n\n   APPENDIX: How to apply the Apache License to your work.\n\n      To apply the Apache License to your work, attach the following\n      boilerplate notice, with the fields enclosed by brackets \"{}\"\n      replaced with your own identifying information. (Don't include\n      the brackets!)  The text should be enclosed in the appropriate\n      comment syntax for the file format. We also recommend that a\n      file or class name and description of purpose be included on the\n      same \"printed page\" as the copyright notice for easier\n      identification within third-party archives.\n\n   Copyright {yyyy} {name of copyright owner}\n\n   Licensed under the Apache License, Version 2.0 (the \"License\");\n   you may not use this file except in compliance with the License.\n   You may obtain a copy of the License at\n\n       http://www.apache.org/licenses/LICENSE-2.0\n\n   Unless required by applicable law or agreed to in writing, software\n   distributed under the License is distributed on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n   See the License for the specific language governing permissions and\n   limitations under the License.\n\n",
             "used_by": [
                 {
@@ -20511,7 +20507,7 @@
                                 "path": null,
                                 "registry": null,
                                 "rename": null,
-                                "req": "=4.5.20",
+                                "req": "=4.5.21",
                                 "source": "registry+https://github.com/rust-lang/crates.io-index",
                                 "target": null,
                                 "uses_default_features": false
@@ -20712,7 +20708,7 @@
                             ]
                         },
                         "homepage": null,
-                        "id": "registry+https://github.com/rust-lang/crates.io-index#clap@4.5.20",
+                        "id": "registry+https://github.com/rust-lang/crates.io-index#clap@4.5.21",
                         "keywords": [
                             "argument",
                             "cli",
@@ -20723,14 +20719,10 @@
                         "license": "MIT OR Apache-2.0",
                         "license_file": null,
                         "links": null,
-                        "manifest_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/Cargo.toml",
+                        "manifest_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/Cargo.toml",
                         "metadata": {
                             "docs": {
                                 "rs": {
-                                    "cargo-args": [
-                                        "-Zunstable-options",
-                                        "-Zrustdoc-scrape-examples"
-                                    ],
                                     "features": [
                                         "unstable-doc"
                                     ],
@@ -20818,7 +20810,7 @@
                                 ],
                                 "name": "clap",
                                 "required-features": [],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/src/lib.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/src/lib.rs",
                                 "test": true
                             },
                             {
@@ -20833,7 +20825,7 @@
                                 ],
                                 "name": "stdio-fixture",
                                 "required-features": [],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/src/bin/stdio-fixture.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/src/bin/stdio-fixture.rs",
                                 "test": true
                             },
                             {
@@ -20850,7 +20842,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/01_quick.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/01_quick.rs",
                                 "test": false
                             },
                             {
@@ -20867,7 +20859,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/01_quick.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/01_quick.rs",
                                 "test": false
                             },
                             {
@@ -20884,7 +20876,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/02_app_settings.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/02_app_settings.rs",
                                 "test": false
                             },
                             {
@@ -20901,7 +20893,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/02_app_settings.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/02_app_settings.rs",
                                 "test": false
                             },
                             {
@@ -20916,7 +20908,7 @@
                                 ],
                                 "name": "02_apps",
                                 "required-features": [],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/02_apps.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/02_apps.rs",
                                 "test": false
                             },
                             {
@@ -20933,7 +20925,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/02_apps.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/02_apps.rs",
                                 "test": false
                             },
                             {
@@ -20950,7 +20942,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/02_crate.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/02_crate.rs",
                                 "test": false
                             },
                             {
@@ -20967,7 +20959,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/02_crate.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/02_crate.rs",
                                 "test": false
                             },
                             {
@@ -20984,7 +20976,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_01_flag_bool.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_01_flag_bool.rs",
                                 "test": false
                             },
                             {
@@ -21001,7 +20993,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_01_flag_bool.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_01_flag_bool.rs",
                                 "test": false
                             },
                             {
@@ -21018,7 +21010,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_01_flag_count.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_01_flag_count.rs",
                                 "test": false
                             },
                             {
@@ -21035,7 +21027,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_01_flag_count.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_01_flag_count.rs",
                                 "test": false
                             },
                             {
@@ -21052,7 +21044,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_02_option.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_02_option.rs",
                                 "test": false
                             },
                             {
@@ -21069,7 +21061,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_02_option.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_02_option.rs",
                                 "test": false
                             },
                             {
@@ -21086,7 +21078,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_02_option_mult.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_02_option_mult.rs",
                                 "test": false
                             },
                             {
@@ -21103,7 +21095,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_02_option_mult.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_02_option_mult.rs",
                                 "test": false
                             },
                             {
@@ -21120,7 +21112,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_03_positional.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_03_positional.rs",
                                 "test": false
                             },
                             {
@@ -21137,7 +21129,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_03_positional.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_03_positional.rs",
                                 "test": false
                             },
                             {
@@ -21154,7 +21146,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_03_positional_mult.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_03_positional_mult.rs",
                                 "test": false
                             },
                             {
@@ -21171,7 +21163,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_03_positional_mult.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_03_positional_mult.rs",
                                 "test": false
                             },
                             {
@@ -21188,7 +21180,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_04_subcommands.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_04_subcommands.rs",
                                 "test": false
                             },
                             {
@@ -21205,7 +21197,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_04_subcommands_alt.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_04_subcommands_alt.rs",
                                 "test": false
                             },
                             {
@@ -21222,7 +21214,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_04_subcommands.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_04_subcommands.rs",
                                 "test": false
                             },
                             {
@@ -21239,7 +21231,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/03_05_default_values.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/03_05_default_values.rs",
                                 "test": false
                             },
                             {
@@ -21256,7 +21248,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/03_05_default_values.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/03_05_default_values.rs",
                                 "test": false
                             },
                             {
@@ -21273,7 +21265,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_01_enum.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_01_enum.rs",
                                 "test": false
                             },
                             {
@@ -21290,7 +21282,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_01_enum.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_01_enum.rs",
                                 "test": false
                             },
                             {
@@ -21307,7 +21299,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_01_possible.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_01_possible.rs",
                                 "test": false
                             },
                             {
@@ -21324,7 +21316,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_02_parse.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_02_parse.rs",
                                 "test": false
                             },
                             {
@@ -21341,7 +21333,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_02_parse.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_02_parse.rs",
                                 "test": false
                             },
                             {
@@ -21358,7 +21350,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_02_validate.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_02_validate.rs",
                                 "test": false
                             },
                             {
@@ -21375,7 +21367,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_02_validate.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_02_validate.rs",
                                 "test": false
                             },
                             {
@@ -21392,7 +21384,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_03_relations.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_03_relations.rs",
                                 "test": false
                             },
                             {
@@ -21409,7 +21401,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_03_relations.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_03_relations.rs",
                                 "test": false
                             },
                             {
@@ -21426,7 +21418,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/04_04_custom.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/04_04_custom.rs",
                                 "test": false
                             },
                             {
@@ -21443,7 +21435,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/04_04_custom.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/04_04_custom.rs",
                                 "test": false
                             },
                             {
@@ -21460,7 +21452,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_builder/05_01_assert.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_builder/05_01_assert.rs",
                                 "test": true
                             },
                             {
@@ -21477,7 +21469,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/tutorial_derive/05_01_assert.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/tutorial_derive/05_01_assert.rs",
                                 "test": true
                             },
                             {
@@ -21492,7 +21484,7 @@
                                 ],
                                 "name": "busybox",
                                 "required-features": [],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/multicall-busybox.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/multicall-busybox.rs",
                                 "test": false
                             },
                             {
@@ -21510,7 +21502,7 @@
                                     "cargo",
                                     "color"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/cargo-example.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/cargo-example.rs",
                                 "test": false
                             },
                             {
@@ -21528,7 +21520,7 @@
                                     "derive",
                                     "color"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/cargo-example-derive.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/cargo-example-derive.rs",
                                 "test": false
                             },
                             {
@@ -21545,7 +21537,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/demo.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/demo.rs",
                                 "test": false
                             },
                             {
@@ -21562,7 +21554,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/escaped-positional.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/escaped-positional.rs",
                                 "test": false
                             },
                             {
@@ -21579,7 +21571,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/escaped-positional-derive.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/escaped-positional-derive.rs",
                                 "test": false
                             },
                             {
@@ -21596,7 +21588,7 @@
                                 "required-features": [
                                     "cargo"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/find.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/find.rs",
                                 "test": false
                             },
                             {
@@ -21611,7 +21603,7 @@
                                 ],
                                 "name": "git",
                                 "required-features": [],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/git.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/git.rs",
                                 "test": false
                             },
                             {
@@ -21628,7 +21620,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/git-derive.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/git-derive.rs",
                                 "test": false
                             },
                             {
@@ -21643,7 +21635,7 @@
                                 ],
                                 "name": "hostname",
                                 "required-features": [],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/multicall-hostname.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/multicall-hostname.rs",
                                 "test": false
                             },
                             {
@@ -21660,7 +21652,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/derive_ref/augment_args.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/derive_ref/augment_args.rs",
                                 "test": false
                             },
                             {
@@ -21677,7 +21669,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/derive_ref/augment_subcommands.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/derive_ref/augment_subcommands.rs",
                                 "test": false
                             },
                             {
@@ -21694,7 +21686,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/derive_ref/flatten_hand_args.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/derive_ref/flatten_hand_args.rs",
                                 "test": false
                             },
                             {
@@ -21711,7 +21703,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/derive_ref/hand_subcommand.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/derive_ref/hand_subcommand.rs",
                                 "test": false
                             },
                             {
@@ -21726,7 +21718,7 @@
                                 ],
                                 "name": "pacman",
                                 "required-features": [],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/pacman.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/pacman.rs",
                                 "test": false
                             },
                             {
@@ -21743,7 +21735,7 @@
                                 "required-features": [
                                     "help"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/repl.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/repl.rs",
                                 "test": false
                             },
                             {
@@ -21760,7 +21752,7 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/repl-derive.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/repl-derive.rs",
                                 "test": false
                             },
                             {
@@ -21777,11 +21769,11 @@
                                 "required-features": [
                                     "derive"
                                 ],
-                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.20/examples/typed-derive.rs",
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap-4.5.21/examples/typed-derive.rs",
                                 "test": false
                             }
                         ],
-                        "version": "4.5.20"
+                        "version": "4.5.21"
                     },
                     "path": null
                 },
@@ -26663,7 +26655,7 @@
             "first_of_kind": false,
             "id": "Apache-2.0",
             "name": "Apache License 2.0",
-            "source_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/autocfg-1.1.0/LICENSE-APACHE",
+            "source_path": "LICENSE-APACHE",
             "text": "                              Apache License\n                        Version 2.0, January 2004\n                     http://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
             "used_by": [
                 {
@@ -31444,7 +31436,7 @@
             "first_of_kind": false,
             "id": "Apache-2.0",
             "name": "Apache License 2.0",
-            "source_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.12/LICENSE-APACHE",
+            "source_path": "LICENSE-APACHE",
             "text": "                              Apache License\n                        Version 2.0, January 2004\n                     https://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n   \"License\" shall mean the terms and conditions for use, reproduction,\n   and distribution as defined by Sections 1 through 9 of this document.\n\n   \"Licensor\" shall mean the copyright owner or entity authorized by\n   the copyright owner that is granting the License.\n\n   \"Legal Entity\" shall mean the union of the acting entity and all\n   other entities that control, are controlled by, or are under common\n   control with that entity. For the purposes of this definition,\n   \"control\" means (i) the power, direct or indirect, to cause the\n   direction or management of such entity, whether by contract or\n   otherwise, or (ii) ownership of fifty percent (50%) or more of the\n   outstanding shares, or (iii) beneficial ownership of such entity.\n\n   \"You\" (or \"Your\") shall mean an individual or Legal Entity\n   exercising permissions granted by this License.\n\n   \"Source\" form shall mean the preferred form for making modifications,\n   including but not limited to software source code, documentation\n   source, and configuration files.\n\n   \"Object\" form shall mean any form resulting from mechanical\n   transformation or translation of a Source form, including but\n   not limited to compiled object code, generated documentation,\n   and conversions to other media types.\n\n   \"Work\" shall mean the work of authorship, whether in Source or\n   Object form, made available under the License, as indicated by a\n   copyright notice that is included in or attached to the work\n   (an example is provided in the Appendix below).\n\n   \"Derivative Works\" shall mean any work, whether in Source or Object\n   form, that is based on (or derived from) the Work and for which the\n   editorial revisions, annotations, elaborations, or other modifications\n   represent, as a whole, an original work of authorship. For the purposes\n   of this License, Derivative Works shall not include works that remain\n   separable from, or merely link (or bind by name) to the interfaces of,\n   the Work and Derivative Works thereof.\n\n   \"Contribution\" shall mean any work of authorship, including\n   the original version of the Work and any modifications or additions\n   to that Work or Derivative Works thereof, that is intentionally\n   submitted to Licensor for inclusion in the Work by the copyright owner\n   or by an individual or Legal Entity authorized to submit on behalf of\n   the copyright owner. For the purposes of this definition, \"submitted\"\n   means any form of electronic, verbal, or written communication sent\n   to the Licensor or its representatives, including but not limited to\n   communication on electronic mailing lists, source code control systems,\n   and issue tracking systems that are managed by, or on behalf of, the\n   Licensor for the purpose of discussing and improving the Work, but\n   excluding communication that is conspicuously marked or otherwise\n   designated in writing by the copyright owner as \"Not a Contribution.\"\n\n   \"Contributor\" shall mean Licensor and any individual or Legal Entity\n   on behalf of whom a Contribution has been received by Licensor and\n   subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   copyright license to reproduce, prepare Derivative Works of,\n   publicly display, publicly perform, sublicense, and distribute the\n   Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of\n   this License, each Contributor hereby grants to You a perpetual,\n   worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n   (except as stated in this section) patent license to make, have made,\n   use, offer to sell, sell, import, and otherwise transfer the Work,\n   where such license applies only to those patent claims licensable\n   by such Contributor that are necessarily infringed by their\n   Contribution(s) alone or by combination of their Contribution(s)\n   with the Work to which such Contribution(s) was submitted. If You\n   institute patent litigation against any entity (including a\n   cross-claim or counterclaim in a lawsuit) alleging that the Work\n   or a Contribution incorporated within the Work constitutes direct\n   or contributory patent infringement, then any patent licenses\n   granted to You under this License for that Work shall terminate\n   as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the\n   Work or Derivative Works thereof in any medium, with or without\n   modifications, and in Source or Object form, provided that You\n   meet the following conditions:\n\n   (a) You must give any other recipients of the Work or\n       Derivative Works a copy of this License; and\n\n   (b) You must cause any modified files to carry prominent notices\n       stating that You changed the files; and\n\n   (c) You must retain, in the Source form of any Derivative Works\n       that You distribute, all copyright, patent, trademark, and\n       attribution notices from the Source form of the Work,\n       excluding those notices that do not pertain to any part of\n       the Derivative Works; and\n\n   (d) If the Work includes a \"NOTICE\" text file as part of its\n       distribution, then any Derivative Works that You distribute must\n       include a readable copy of the attribution notices contained\n       within such NOTICE file, excluding those notices that do not\n       pertain to any part of the Derivative Works, in at least one\n       of the following places: within a NOTICE text file distributed\n       as part of the Derivative Works; within the Source form or\n       documentation, if provided along with the Derivative Works; or,\n       within a display generated by the Derivative Works, if and\n       wherever such third-party notices normally appear. The contents\n       of the NOTICE file are for informational purposes only and\n       do not modify the License. You may add Your own attribution\n       notices within Derivative Works that You distribute, alongside\n       or as an addendum to the NOTICE text from the Work, provided\n       that such additional attribution notices cannot be construed\n       as modifying the License.\n\n   You may add Your own copyright statement to Your modifications and\n   may provide additional or different license terms and conditions\n   for use, reproduction, or distribution of Your modifications, or\n   for any such Derivative Works as a whole, provided Your use,\n   reproduction, and distribution of the Work otherwise complies with\n   the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise,\n   any Contribution intentionally submitted for inclusion in the Work\n   by You to the Licensor shall be under the terms and conditions of\n   this License, without any additional terms or conditions.\n   Notwithstanding the above, nothing herein shall supersede or modify\n   the terms of any separate license agreement you may have executed\n   with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade\n   names, trademarks, service marks, or product names of the Licensor,\n   except as required for reasonable and customary use in describing the\n   origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or\n   agreed to in writing, Licensor provides the Work (and each\n   Contributor provides its Contributions) on an \"AS IS\" BASIS,\n   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n   implied, including, without limitation, any warranties or conditions\n   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n   PARTICULAR PURPOSE. You are solely responsible for determining the\n   appropriateness of using or redistributing the Work and assume any\n   risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory,\n   whether in tort (including negligence), contract, or otherwise,\n   unless required by applicable law (such as deliberate and grossly\n   negligent acts) or agreed to in writing, shall any Contributor be\n   liable to You for damages, including any direct, indirect, special,\n   incidental, or consequential damages of any character arising as a\n   result of this License or out of the use or inability to use the\n   Work (including but not limited to damages for loss of goodwill,\n   work stoppage, computer failure or malfunction, or any and all\n   other commercial damages or losses), even if such Contributor\n   has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing\n   the Work or Derivative Works thereof, You may choose to offer,\n   and charge a fee for, acceptance of support, warranty, indemnity,\n   or other liability obligations and/or rights consistent with this\n   License. However, in accepting such obligations, You may act only\n   on Your own behalf and on Your sole responsibility, not on behalf\n   of any other Contributor, and only if You agree to indemnify,\n   defend, and hold each Contributor harmless for any liability\n   incurred by, or claims asserted against, such Contributor by reason\n   of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\n   To apply the Apache License to your work, attach the following\n   boilerplate notice, with the fields enclosed by brackets \"[]\"\n   replaced with your own identifying information. (Don't include\n   the brackets!)  The text should be enclosed in the appropriate\n   comment syntax for the file format. We also recommend that a\n   file or class name and description of purpose be included on the\n   same \"printed page\" as the copyright notice for easier\n   identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n\thttps://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
             "used_by": [
                 {
@@ -32172,7 +32164,7 @@
                         "edition": "2021",
                         "features": {},
                         "homepage": null,
-                        "id": "path+file:///Users/aimami/experiments/rust-projects/gh-bofh-rs#1.2.0",
+                        "id": "path+file:///Users/aimami/experiments/rust-projects/gh-bofh-rs#1.2.1-next.1",
                         "keywords": [],
                         "license": "MIT OR Apache-2.0",
                         "license_file": null,
@@ -32216,7 +32208,7 @@
                                 "test": true
                             }
                         ],
-                        "version": "1.2.0"
+                        "version": "1.2.1-next.1"
                     },
                     "path": null
                 },
@@ -33514,7 +33506,7 @@
             "first_of_kind": false,
             "id": "MIT",
             "name": "MIT License",
-            "source_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aho-corasick-1.1.2/LICENSE-MIT",
+            "source_path": "LICENSE-MIT",
             "text": "The MIT License (MIT)\n\nCopyright (c) 2015 Andrew Gallant\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
             "used_by": [
                 {
@@ -33880,6 +33872,126 @@
             "source_path": "COPYING",
             "text": "This project is dual-licensed under the Unlicense and MIT licenses.\n\nYou may use this code under the terms of either license.\n",
             "used_by": [
+                {
+                    "crate": {
+                        "authors": [
+                            "Andrew Gallant <jamslam@gmail.com>"
+                        ],
+                        "categories": [
+                            "text-processing"
+                        ],
+                        "default_run": null,
+                        "dependencies": [
+                            {
+                                "features": [],
+                                "kind": "normal",
+                                "name": "log",
+                                "optional": true,
+                                "path": null,
+                                "registry": null,
+                                "rename": null,
+                                "req": "^0.4.17",
+                                "source": "registry+https://github.com/rust-lang/crates.io-index",
+                                "target": null,
+                                "uses_default_features": true
+                            },
+                            {
+                                "features": [],
+                                "kind": "normal",
+                                "name": "memchr",
+                                "optional": true,
+                                "path": null,
+                                "registry": null,
+                                "rename": null,
+                                "req": "^2.4.0",
+                                "source": "registry+https://github.com/rust-lang/crates.io-index",
+                                "target": null,
+                                "uses_default_features": false
+                            },
+                            {
+                                "features": [],
+                                "kind": "dev",
+                                "name": "doc-comment",
+                                "optional": false,
+                                "path": null,
+                                "registry": null,
+                                "rename": null,
+                                "req": "^0.3.3",
+                                "source": "registry+https://github.com/rust-lang/crates.io-index",
+                                "target": null,
+                                "uses_default_features": true
+                            }
+                        ],
+                        "description": "Fast multiple substring searching.",
+                        "documentation": null,
+                        "edition": "2021",
+                        "features": {
+                            "default": [
+                                "std",
+                                "perf-literal"
+                            ],
+                            "logging": [
+                                "dep:log"
+                            ],
+                            "perf-literal": [
+                                "dep:memchr"
+                            ],
+                            "std": [
+                                "memchr?/std"
+                            ]
+                        },
+                        "homepage": "https://github.com/BurntSushi/aho-corasick",
+                        "id": "registry+https://github.com/rust-lang/crates.io-index#aho-corasick@1.1.2",
+                        "keywords": [
+                            "string",
+                            "search",
+                            "text",
+                            "pattern",
+                            "multi"
+                        ],
+                        "license": "Unlicense OR MIT",
+                        "license_file": null,
+                        "links": null,
+                        "manifest_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aho-corasick-1.1.2/Cargo.toml",
+                        "metadata": {
+                            "docs": {
+                                "rs": {
+                                    "all-features": true,
+                                    "rustdoc-args": [
+                                        "--cfg",
+                                        "docsrs",
+                                        "--generate-link-to-definition"
+                                    ]
+                                }
+                            }
+                        },
+                        "name": "aho-corasick",
+                        "publish": null,
+                        "readme": "README.md",
+                        "repository": "https://github.com/BurntSushi/aho-corasick",
+                        "rust_version": "1.60.0",
+                        "source": "registry+https://github.com/rust-lang/crates.io-index",
+                        "targets": [
+                            {
+                                "crate_types": [
+                                    "lib"
+                                ],
+                                "doc": true,
+                                "doctest": true,
+                                "edition": "2021",
+                                "kind": [
+                                    "lib"
+                                ],
+                                "name": "aho_corasick",
+                                "required-features": [],
+                                "src_path": "/Users/aimami/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aho-corasick-1.1.2/src/lib.rs",
+                                "test": true
+                            }
+                        ],
+                        "version": "1.1.2"
+                    },
+                    "path": null
+                },
                 {
                     "crate": {
                         "authors": [
@@ -34251,7 +34363,7 @@
             "text": "\n                                 Apache License\n                           Version 2.0, January 2004\n                        http://www.apache.org/licenses/\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor,\n      except as required for reasonable and customary use in describing the\n      origin of the Work and reproducing the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n   END OF TERMS AND CONDITIONS\n"
         },
         {
-            "count": 9,
+            "count": 10,
             "id": "MIT",
             "indices": [
                 18,


### PR DESCRIPTION
This pull request includes significant changes to the licensing information in the `about.toml` file. The modifications involve the removal of several license specifications and the addition of new ones for different packages.

Key changes include:

* Removed license specifications for `stability`, `proc-macro2`, `anyhow`, `ratatui`, and `document-features` packages.
* Added license specifications for `rustix` and `linux-raw-sys` packages, including multiple license options and corresponding checksums.