### PR TITLE
test: add integration tests for the binary

### DIFF
--- a/src/gh_bofh/main.rs
+++ b/src/gh_bofh/main.rs
@@ -18,8 +18,19 @@ use gh_bofh_lib::{
 
 fn main() {
     let arguments = Cli::parse();
-    match arguments.excuse_type {
+    let chosen_type = process_choice(&arguments);
+    match chosen_type {
         ExcuseType::Classic => println!("{}", random_classic()),
         ExcuseType::Modern => println!("{}", random_modern()),
+    }
+}
+
+fn process_choice(arguments: &Cli) -> ExcuseType {
+    if arguments.classic {
+        ExcuseType::Classic
+    } else if arguments.modern {
+        ExcuseType::Modern
+    } else {
+        arguments.excuse_type
     }
 }

--- a/tests/test_binary_classic.rs
+++ b/tests/test_binary_classic.rs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+//
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use assert_cmd::Command;
+use gh_bofh_lib::CLASSIC;
+
+#[test]
+fn test_binary_plain_default() {
+    let mut cmd = Command::cargo_bin("gh-bofh").unwrap();
+    cmd.assert().success();
+}
+
+#[test]
+fn test_binary_output_classic() {
+    let cmd = Command::cargo_bin("gh-bofh").unwrap().output().unwrap();
+    assert!(cmd.status.success());
+    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+    assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+}
+
+#[test]
+fn test_binary_output_flag_classic() {
+    let cmd = Command::cargo_bin("gh-bofh")
+        .unwrap()
+        .args(["--type", "classic"])
+        .output()
+        .unwrap();
+    assert!(cmd.status.success());
+    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+    assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+}
+
+#[test]
+fn test_binary_output_flag_short_classic() {
+    let cmd = Command::cargo_bin("gh-bofh")
+        .unwrap()
+        .arg("-c")
+        .output()
+        .unwrap();
+    assert!(cmd.status.success());
+    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+    assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+}
+
+#[test]
+fn test_binary_output_env_var_classic() {
+    let cmd = Command::cargo_bin("gh-bofh")
+        .unwrap()
+        .env("EXCUSE_TYPE", "classic")
+        .output()
+        .unwrap();
+    assert!(cmd.status.success());
+    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+    assert!(CLASSIC.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+}

--- a/tests/test_binary_modern.rs
+++ b/tests/test_binary_modern.rs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+//
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use assert_cmd::Command;
+use gh_bofh_lib::MODERN;
+
+#[test]
+fn test_binary_output_modern() {
+    let cmd = Command::cargo_bin("gh-bofh").unwrap().output().unwrap();
+    assert!(cmd.status.success());
+    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+    assert!(!MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+}
+
+#[test]
+fn test_binary_output_flag_modern() {
+    let cmd = Command::cargo_bin("gh-bofh")
+        .unwrap()
+        .args(["--type", "modern"])
+        .output()
+        .unwrap();
+    assert!(cmd.status.success());
+    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+    assert!(MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+}
+
+#[test]
+fn test_binary_output_flag_short_modern() {
+    let cmd = Command::cargo_bin("gh-bofh")
+        .unwrap()
+        .arg("-m")
+        .output()
+        .unwrap();
+    println!("{:?}", cmd);
+    assert!(cmd.status.success());
+    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+    assert!(MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+}
+
+#[test]
+fn test_binary_output_env_var_modern() {
+    let cmd = Command::cargo_bin("gh-bofh")
+        .unwrap()
+        .env("EXCUSE_TYPE", "modern")
+        .output()
+        .unwrap();
+    assert!(cmd.status.success());
+    assert!(!String::from_utf8_lossy(&cmd.stdout).is_empty());
+    assert!(String::from_utf8_lossy(&cmd.stderr).is_empty());
+    assert!(MODERN.contains(&String::from_utf8_lossy(&cmd.stdout).trim()));
+}


### PR DESCRIPTION
### TL;DR
Added comprehensive binary testing and improved excuse type handling

### What changed?
- Introduced a new `process_choice` function to handle excuse type selection
- Added test files for both classic and modern excuse types
- Implemented tests for command-line flags, environment variables, and default behavior
- Added validation to ensure correct output types are generated

### How to test?
1. Run `cargo test` to execute all test cases
2. Try different command variations:
   - Default: `gh-bofh`
   - Classic type: `gh-bofh --type classic` or `gh-bofh -c`
   - Modern type: `gh-bofh --type modern` or `gh-bofh -m`
   - Environment variable: `EXCUSE_TYPE=classic gh-bofh`

### Why make this change?
To ensure reliable functionality across different input methods and improve the robustness of the excuse generation system through comprehensive testing. This change helps validate that the correct excuse types are generated based on user input, whether through command-line arguments or environment variables.