### PR TITLE
ci: update and validate pre-commit config on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,11 +48,11 @@ repos:
           files: "Cargo.toml$"
           pass_filenames: true
     - repo: https://github.com/commitizen-tools/commitizen
-      rev: v3.13.0
+      rev: v4.0.0
       hooks:
         - id: commitizen
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.5.0
+      rev: v5.0.0
       hooks:
         - id: check-json
           exclude: ".vscode/.*json"
@@ -77,7 +77,7 @@ repos:
           id: trailing-whitespace
           exclude: "licenses_report.md"
     - repo: https://github.com/compilerla/conventional-pre-commit
-      rev: v3.0.0
+      rev: v3.6.0
       hooks:
         - args:
             - build
@@ -96,43 +96,43 @@ repos:
           stages:
             - commit-msg
     - repo: https://github.com/Lucas-C/pre-commit-hooks
-      rev: v1.5.4
+      rev: v1.5.5
       hooks:
         - id: forbid-crlf
         - id: remove-crlf
         - id: forbid-tabs
         - id: remove-tabs
     - repo: https://github.com/google/yamlfmt
-      rev: v0.10.0
+      rev: v0.14.0
       hooks:
         - id: yamlfmt
           exclude: ".github/workflows/.*\\.ya?ml"
     - repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: v0.37.0
+      rev: v0.43.0
       hooks:
         - args:
             - --ignore
             - CHANGELOG.md
           id: markdownlint
     - repo: https://github.com/Yelp/detect-secrets
-      rev: v1.4.0
+      rev: v1.5.0
       hooks:
         - id: detect-secrets
           args: ["--baseline", ".secrets.baseline"]
           exclude: "meta/licenses.*"
     - repo: https://github.com/sirosen/texthooks
-      rev: 0.6.3
+      rev: 0.6.7
       hooks:
         - id: fix-smartquotes
           exclude: "licenses.*"
         - id: fix-ligatures
         - id: forbid-bidi-controls
     - repo: https://github.com/zricethezav/gitleaks
-      rev: v8.18.1
+      rev: v8.21.2
       hooks:
         - id: gitleaks
     - repo: https://github.com/fsfe/reuse-tool
-      rev: v4.0.2
+      rev: v5.0.2
       hooks:
         - id: reuse
     - repo: https://github.com/jumanjihouse/pre-commit-hooks

--- a/licenses_report.json
+++ b/licenses_report.json
@@ -7579,6 +7579,36 @@
                         "kind": [
                             "test"
                         ],
+                        "name": "test_binary_classic",
+                        "required-features": [],
+                        "src_path": "/Users/aimami/experiments/rust-projects/gh-bofh-rs/tests/test_binary_classic.rs",
+                        "test": true
+                    },
+                    {
+                        "crate_types": [
+                            "bin"
+                        ],
+                        "doc": false,
+                        "doctest": false,
+                        "edition": "2021",
+                        "kind": [
+                            "test"
+                        ],
+                        "name": "test_binary_modern",
+                        "required-features": [],
+                        "src_path": "/Users/aimami/experiments/rust-projects/gh-bofh-rs/tests/test_binary_modern.rs",
+                        "test": true
+                    },
+                    {
+                        "crate_types": [
+                            "bin"
+                        ],
+                        "doc": false,
+                        "doctest": false,
+                        "edition": "2021",
+                        "kind": [
+                            "test"
+                        ],
                         "name": "test_common_excuses",
                         "required-features": [],
                         "src_path": "/Users/aimami/experiments/rust-projects/gh-bofh-rs/tests/test_common_excuses.rs",
@@ -34727,6 +34757,36 @@
                                 "name": "gh-bofh",
                                 "required-features": [],
                                 "src_path": "/Users/aimami/experiments/rust-projects/gh-bofh-rs/src/gh_bofh/main.rs",
+                                "test": true
+                            },
+                            {
+                                "crate_types": [
+                                    "bin"
+                                ],
+                                "doc": false,
+                                "doctest": false,
+                                "edition": "2021",
+                                "kind": [
+                                    "test"
+                                ],
+                                "name": "test_binary_classic",
+                                "required-features": [],
+                                "src_path": "/Users/aimami/experiments/rust-projects/gh-bofh-rs/tests/test_binary_classic.rs",
+                                "test": true
+                            },
+                            {
+                                "crate_types": [
+                                    "bin"
+                                ],
+                                "doc": false,
+                                "doctest": false,
+                                "edition": "2021",
+                                "kind": [
+                                    "test"
+                                ],
+                                "name": "test_binary_modern",
+                                "required-features": [],
+                                "src_path": "/Users/aimami/experiments/rust-projects/gh-bofh-rs/tests/test_binary_modern.rs",
                                 "test": true
                             },
                             {

--- a/licenses_report.md
+++ b/licenses_report.md
@@ -11,7 +11,7 @@ This page lists the licenses of the projects used in cargo-about.
 
 ## Overview of licenses
 
-- [Apache License 2.0](#Apache-2.0) (75)
+- [Apache License 2.0](#Apache-2.0) (74)
 - [MIT License](#MIT) (13)
 - [Unicode License Agreement - Data Files and Software (2016)](#Unicode-DFS-2016) (1)
 
@@ -1548,8 +1548,6 @@ Apache License 2.0
 - [libc]( https://github.com/rust-lang/libc ) 0.2.152
 - [proc-macro2]( https://github.com/dtolnay/proc-macro2 ) 1.0.86
 - [quote]( https://github.com/dtolnay/quote ) 1.0.37
-- [semver]( https://github.com/dtolnay/semver ) 1.0.21
-- [syn]( https://github.com/dtolnay/syn ) 2.0.79
 - [unicode-ident]( https://github.com/dtolnay/unicode-ident ) 1.0.13
 - [utf8parse]( https://github.com/alacritty/vte ) 0.2.1
 
@@ -3454,30 +3452,10 @@ Apache License 2.0
 
 #### Used by
 
-- [rusty-forkfork]( https://github.com/oknozor/rusty-forkfork ) 0.4.0
-
-#### License
-
-```text
-//-
-// Copyright 2018
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
-```
-
-### Apache-2.0
-
-Apache License 2.0
-
-#### Used by
-
 - [gh-bofh-rs]( https://github.com/AliSajid/gh-bofh-rs ) 1.2.1-next.1
 - [relative-path]( https://github.com/udoprog/relative-path ) 1.9.3
+- [semver]( https://github.com/dtolnay/semver ) 1.0.21
+- [syn]( https://github.com/dtolnay/syn ) 2.0.79
 
 #### License
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,15 +14,14 @@ PREFIX="gh-bofh"
 
 # Declare the associative array mapping Rust triple to Go arch
 declare -A GOARCH_MAP=(
-    ["aarch64-apple-darwin"]="darwin-arm64"
-    ["x86_64-apple-darwin"]="darwin-amd64"
-    ["i686-pc-windows-gnu"]="windows-386"
-    ["x86_64-pc-windows-gnu"]="windows-amd64"
-    ["i686-unknown-linux-gnu"]="linux-386"
-    ["x86_64-unknown-linux-gnu"]="linux-amd64"
-    ["aarch64-unknown-linux-gnu"]="linux-arm64"
+  ["aarch64-apple-darwin"]="darwin-arm64"
+  ["x86_64-apple-darwin"]="darwin-amd64"
+  ["i686-pc-windows-gnu"]="windows-386"
+  ["x86_64-pc-windows-gnu"]="windows-amd64"
+  ["i686-unknown-linux-gnu"]="linux-386"
+  ["x86_64-unknown-linux-gnu"]="linux-amd64"
+  ["aarch64-unknown-linux-gnu"]="linux-arm64"
 )
-
 
 # Check the files in the source folder
 tree artifacts
@@ -31,14 +30,16 @@ tree artifacts
 mkdir -p dist
 
 # Copy binaries with the rust triple and go arch names to the dist folder
-for arch in $(ls artifacts); do
-  filename=$PREFIX-$arch
-  if [ -f "artifacts/$arch/$filename" ]; then
-    cp -v "artifacts/$arch/$filename" "dist/$filename"
-    cp -v "artifacts/$arch/$filename" "dist/$PREFIX-${GOARCH_MAP[$arch]}"
+for arch in artifacts/*/; do
+  if [ -d "$arch" ]; then
+    arch=$(basename "$arch")
+    filename=$PREFIX-$arch
+    if [ -f "artifacts/$arch/$filename" ]; then
+      cp -v "artifacts/$arch/$filename" "dist/$filename"
+      cp -v "artifacts/$arch/$filename" "dist/$PREFIX-${GOARCH_MAP[$arch]}"
+    fi
   fi
 done
-
 
 # Create the checksums
 shasum -a 256 dist/* | sed 's/dist\///' | tee dist/SHA256SUMS.txt


### PR DESCRIPTION
### TL;DR

Updates pre-commit hook versions and improves build script functionality.

### What changed?

- Updated pre-commit hook versions:
  - commitizen to v4.0.0
  - pre-commit-hooks to v5.0.0
  - conventional-pre-commit to v3.6.0
  - Lucas-C/pre-commit-hooks to v1.5.5
  - yamlfmt to v0.14.0
  - markdownlint-cli to v0.43.0
  - detect-secrets to v1.5.0
  - texthooks to v0.6.7
  - gitleaks to v8.21.2
  - reuse-tool to v5.0.2
- Enhanced build script with improved directory handling and safer file operations
- Added new test binaries: test_binary_classic and test_binary_modern
- Updated license report files to reflect current dependencies

### How to test?

1. Run pre-commit hooks to verify they work with new versions
2. Execute the build script to ensure proper artifact generation
3. Verify the new test binaries are properly included
4. Check SHA256SUMS.txt generation is working correctly

### Why make this change?

To maintain security and stability by keeping pre-commit hooks up to date with their latest versions, while improving the build process reliability through better file handling and additional test coverage.