### PR TITLE
docs: add a GOVERNANCE file

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: MIT
+-->
+
+# Project Governance Model
+
+## Overview
+
+This document outlines how decisions are made for this project, defines the roles of contributors, and establishes how conflicts are resolved.
+
+## Roles and Responsibilities
+
+### Project Owner
+
+The Project Owner currently makes all final decisions on the project's direction, design, and functionality. This role is responsible for:
+
+-   Approving or rejecting contributions (such as pull requests)
+-   Setting the project roadmap and priorities
+-   Managing project releases
+-   Resolving disputes or conflicting opinions
+
+### Contributors
+
+Contributors are anyone who submits code, documentation, or other changes to the project. Contributions are made via pull requests and are subject to review by the Project Owner. Contributors:
+
+-   Suggest improvements to the project
+-   Participate in discussions and feedback sessions
+-   Submit code, documentation, or bug reports
+
+## Decision-Making Process
+
+Decisions are currently made by the Project Owner based on project needs, feedback from contributors, and long-term project vision. As the project grows, decision-making may evolve to include more collaborative processes.
+
+## Conflict Resolution
+
+If disagreements arise, the Project Owner will have the final say. The Project Owner will take into account all feedback and suggestions before making a decision.
+
+## Future Governance Changes
+
+As the project grows and gains more contributors, the governance model may shift to include a more formal process, such as meritocracy or group maintainers, to better accommodate additional contributors. Any changes to this governance structure will be reflected in this document.


### PR DESCRIPTION
### TL;DR
Added a GOVERNANCE.md file to establish project decision-making processes and roles.

### What changed?
Created a new GOVERNANCE.md file that defines:
- Project Owner and Contributor roles and responsibilities
- Decision-making processes
- Conflict resolution procedures
- Future governance evolution plans

### How to test?
Review the GOVERNANCE.md file to ensure:
- All sections are properly formatted
- Content is clear and understandable
- Links and references are correct
- Document adheres to the dual Apache-2.0 and MIT licensing

### Why make this change?
To establish clear guidelines for project governance and provide transparency about:
- How decisions are made
- Who has authority over different aspects of the project
- How contributors can participate
- How conflicts are resolved
This structure will help scale the project and manage contributions effectively.