### PR TITLE
docs: add a future ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,27 @@
+<!--
+SPDX-FileCopyrightText: 2024 Ali Sajid Imami
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: MIT
+-->
+
+# Project Roadmap
+
+## Overview
+
+This project is currently functionally stable, and no new functionality is planned. Our primary focus will be on maintaining the existing features and expanding the list of Bastard Operator From Hell (BOFH) style excuses.
+
+## Planned Updates
+
+- **Excuse List Expansion**: We're going to add more BOFH-style excuses to keep your users bewildered and your sanity intact.
+
+## Maintenance
+
+- **Bug Fixes**: Squashing bugs like the ruthless operator you are.
+- **Performance Improvements**: Making sure the extension runs smoother than your best excuse.
+
+## Community Involvement
+
+- **Feedback and Suggestions**: Got a killer excuse? Share it with us, and it might just make the list.
+
+Thank you for your continued support, and remember: it's always the user's fault!


### PR DESCRIPTION
### TL;DR
Added a project roadmap document outlining future plans and maintenance strategy.

### What changed?
Created a new ROADMAP.md file that outlines the project's future direction, focusing on maintaining existing features and expanding the BOFH-style excuse list. The document includes sections for planned updates, maintenance activities, and community involvement opportunities.

### How to test?
1. Navigate to the ROADMAP.md file in the repository
2. Verify that all sections are present and properly formatted
3. Ensure the document is accessible and readable
4. Confirm that the license headers are correctly included

### Why make this change?
To provide transparency about the project's direction and set clear expectations for contributors and users. This roadmap helps communicate that while the project is functionally stable, we're committed to maintaining it and expanding the excuse database with community input.