### PR TITLE
docs: update the badges in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,24 @@ SPDX-License-Identifier: MIT
 
 # A `gh` plugin to generate BOFH excuses
 
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/AliSajid/gh-bofh-rs)
-![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/AliSajid/gh-bofh-rs)
-![Crates.io Version](https://img.shields.io/crates/v/gh-bofh-rs)
-![Crates.io Size](https://img.shields.io/crates/size/gh-bofh-rs)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/AliSajid/gh-bofh-rs)](https://github.com/AliSajid/gh-bofh-rs/releases/latest)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/AliSajid/gh-bofh-rs)](https://github.com/AliSajid/gh-bofh-rs/releases/latest)
+[![Crates.io Version](https://img.shields.io/crates/v/gh-bofh-rs)](https://crates.io/crates/gh-bofh-rs)
+[![Crates.io Size](https://img.shields.io/crates/size/gh-bofh-rs)](https://crates.io/crates/gh-bofh-rs)
 ![Maintenance](https://img.shields.io/maintenance/yes/2024)
 ![OSS Lifecycle](https://img.shields.io/osslifecycle?file_url=https%3A%2F%2Fraw.githubusercontent.com%2FAliSajid%2Fgh-bofh-rs%2Fmain%2FOSSMETADATA)
 
 [![Continuous integration](https://github.com/AliSajid/gh-bofh-rs/actions/workflows/ci.yaml/badge.svg?branch=main&event=push)](https://github.com/AliSajid/gh-bofh-rs/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/AliSajid/gh-bofh-rs/graph/badge.svg?token=rrsVYywjlx)](https://codecov.io/gh/AliSajid/gh-bofh-rs)
 [![Security Audit](https://github.com/AliSajid/gh-bofh-rs/actions/workflows/audit.yaml/badge.svg?branch=main)](https://github.com/AliSajid/gh-bofh-rs/actions/workflows/audit.yaml)
-![GitHub issues](https://img.shields.io/github/issues/AliSajid/gh-bofh-rs)
+[![GitHub issues](https://img.shields.io/github/issues/AliSajid/gh-bofh-rs)](https://github.com/AliSajid/gh-bofh-rs/issues)
 
-![Crates.io License](https://img.shields.io/crates/l/gh-bofh-rs)
-![REUSE Compliance](https://img.shields.io/reuse/compliance/github.com%2FAliSajid%2Fgh-bofh-rs)
+[![Crates.io License](https://img.shields.io/crates/l/gh-bofh-rs)](https://crates.io/crates/gh-bofh-rs)
+[![REUSE Compliance](https://img.shields.io/reuse/compliance/github.com%2FAliSajid%2Fgh-bofh-rs)](https://api.reuse.software/info/github.com/AliSajid/gh-bofh-rs)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9466/badge)](https://www.bestpractices.dev/projects/9466)
 
-![Libraries.io SourceRank](https://img.shields.io/librariesio/sourcerank/cargo/gh-bofh-rs)
-![ClearlyDefined Score](https://img.shields.io/clearlydefined/score/crate/cratesio/-/gh-bofh-rs/1.1.3)
+[![Libraries.io SourceRank](https://img.shields.io/librariesio/sourcerank/cargo/gh-bofh-rs)](https://libraries.io/cargo/gh-bofh-rs)
+[![ClearlyDefined Score](https://img.shields.io/clearlydefined/score/crate/cratesio/-/gh-bofh-rs/1.2.0-next.1)](https://clearlydefined.io/definitions/crate/cratesio/-/gh-bofh-rs/1.2.0-next.1)
 
 Generate a BOFH Excuse for github-cli from the commandline as a `gh` extension.
 


### PR DESCRIPTION
Added clickable links to all badges in README.md

The badges in the README.md now link to their respective destinations, including:
- Release and tag badges link to latest GitHub releases
- Crates.io badges link to the package page
- Issues badge links to GitHub issues
- License badge links to Crates.io
- REUSE compliance badge links to REUSE API info
- Libraries.io badge links to package page
- ClearlyDefined score links to definition page

Also updated ClearlyDefined badge to reference version 1.2.0-next.1

Signed-off-by: Ali Sajid Imami <395482+AliSajid@users.noreply.github.com>