### PR TITLE
refactor: migrate to rand v0.9.0

### DIFF
--- a/src/gh_bofh_lib/excuses.rs
+++ b/src/gh_bofh_lib/excuses.rs
@@ -16,10 +16,10 @@
 ///
 /// ```
 /// use gh_bofh_lib::excuses::CLASSIC;
-/// use rand::seq::SliceRandom;
+/// use rand::prelude::IndexedRandom;
 ///
 /// // Print a random excuse
-/// let excuse = CLASSIC.choose(&mut rand::thread_rng()).unwrap();
+/// let excuse = CLASSIC.choose(&mut rand::rng()).unwrap();
 /// println!("Excuse: {}", excuse);
 /// ```
 ///
@@ -525,10 +525,10 @@ pub const CLASSIC: [&str; 467] = [
 ///
 /// ```
 /// use gh_bofh_lib::excuses::MODERN;
-/// use rand::seq::SliceRandom;
+/// use rand::prelude::IndexedRandom;
 ///
 /// // Print a random excuse
-/// let excuse = MODERN.choose(&mut rand::thread_rng()).unwrap();
+/// let excuse = MODERN.choose(&mut rand::rng()).unwrap();
 /// println!("Excuse: {}", excuse);
 /// ```
 ///

--- a/src/gh_bofh_lib/lib.rs
+++ b/src/gh_bofh_lib/lib.rs
@@ -73,7 +73,7 @@ pub use excuses::{
     CLASSIC,
     MODERN,
 };
-use rand::seq::SliceRandom;
+use rand::prelude::IndexedRandom;
 
 type ClassicExcuse = &'static str;
 type ModernExcuse = &'static str;
@@ -93,7 +93,7 @@ type ModernExcuse = &'static str;
 #[must_use]
 pub fn random_classic() -> ClassicExcuse {
     CLASSIC
-        .choose(&mut rand::thread_rng())
+        .choose(&mut rand::rng())
         .unwrap_or(&"No excuse found, try again later")
 }
 
@@ -113,7 +113,7 @@ pub fn random_classic() -> ClassicExcuse {
 #[must_use]
 pub fn random_modern() -> ModernExcuse {
     MODERN
-        .choose(&mut rand::thread_rng())
+        .choose(&mut rand::rng())
         .unwrap_or(&"Excuse engine not initialized. Please try again later.")
 }
 


### PR DESCRIPTION
### TL;DR

Updated the random excuse generation to use the newer rand API.

### What changed?

- Replaced `rand::seq::SliceRandom` with `rand::prelude::IndexedRandom`
- Replaced `rand::thread_rng()` with `rand::rng()` in all examples and function implementations
- Updated both the documentation examples and the actual implementation code

### How to test?

1. Run the existing tests to ensure they pass with the new API
2. Try generating random excuses using both `random_classic()` and `random_modern()` functions
3. Verify that the examples in the documentation still work correctly

### Why make this change?

The rand crate has evolved its API, and this change updates our code to use the newer, recommended interfaces. Using `IndexedRandom` from the prelude and the simpler `rng()` function improves code maintainability and ensures compatibility with future versions of the rand crate.