### PR TITLE
build: update the copyright years

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT

--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT

--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: MIT

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
@@ -11,77 +11,77 @@ SPDX-PackageDownloadLocation = "https://github.com/AliSajid/aaprop"
 [[annotations]]
 path = ".gitignore"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ".gitleaksignore"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ".markdownlintignore"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ".markdownlint.json"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = "Cargo.lock"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "MIT AND Apache-2.0"
 
 [[annotations]]
 path = ".secrets.baseline"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = ".vscode/**.json"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = "licenses_report.json"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "Apache-2.0 AND MIT"
 
 [[annotations]]
 path = ".gitpod.Dockerfile"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = "CHANGELOG.md"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = "renovate.json"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "MIT AND Apache-2.0"
 
 [[annotations]]
 path = ".github/.codecov.yaml"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = "OSSMETADATA"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2023 - 2024 Ali Sajid Imami"
+SPDX-FileCopyrightText = "2023 - 2025 Ali Sajid Imami"
 SPDX-License-Identifier = "CC0-1.0"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: MIT

--- a/meta/licenses.hbs
+++ b/meta/licenses.hbs
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: MIT

--- a/src/gh_bofh/cli.rs
+++ b/src/gh_bofh/cli.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024
-// SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT

--- a/src/gh_bofh/main.rs
+++ b/src/gh_bofh/main.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024
-// SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT

--- a/src/gh_bofh_lib/excuses.rs
+++ b/src/gh_bofh_lib/excuses.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024
-// SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT

--- a/src/gh_bofh_lib/lib.rs
+++ b/src/gh_bofh_lib/lib.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2024
-// SPDX-FileCopyrightText: 2023 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT


### PR DESCRIPTION
### TL;DR

Updated copyright year range to include 2025 across all project files.

### What changed?

Modified the SPDX-FileCopyrightText headers in all source files, workflow configurations, and documentation to extend the copyright year range from "2023 - 2024" to "2023 - 2025". This includes:

- GitHub workflow files (.github/workflows/*.yaml)
- README.md and SECURITY.md
- REUSE.toml file and all its annotations
- Source code files in src/gh_bofh and src/gh_bofh_lib directories
- Template files (meta/licenses.hbs)

### How to test?

Verify that all files have the updated copyright year range "2023 - 2025" in their SPDX headers. No functional changes were made, so no additional testing is required.

### Why make this change?

This is a proactive update to the copyright notices to include the upcoming year 2025, ensuring that the project's copyright information remains current and accurate for the foreseeable future.