### PR TITLE
docs: add a SECURITY_REQUIREMENTS.md file

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MIT
 
 ## **Overview**
 
-The `gh-bofh` project is a GitHub CLI extension that generates random BOFH (Bastard Operator From Hell) excuses. The project consists of two main components:
+The `gh-bofh-rs` project is a GitHub CLI extension that generates random BOFH (Bastard Operator From Hell) excuses. The project consists of two main components:
 
 1. **Library (`gh_bofh_lib`)**: A Rust library that provides the core functionality for generating random excuses and contains a list of pre-defined excuses.
 2. **CLI (`gh-bofh`)**: A binary crate that acts as a command-line interface for the library, allowing users to generate excuses via the command line.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,12 @@ If you want to contribute to this project, please read the [CONTRIBUTING.md](CON
 ### High Level Overview
 
 The architecture documentation can be found in the project repository under the following URL:  
-[Architecture Documentation](https://github.com/your-username/gh-bofh/blob/main/ARCHITECTURE.md)
+[Architecture Documentation](ARCHITECTURE.md)
+
+### Security Requirements
+
+The security requirements and expectations documentation can be found in the project repository under the following URL:  
+[Security Requirements Documentation](SECURITY_REQUIREMENTS.md)
 
 ## License
 

--- a/SECURITY_REQUIREMENTS.md
+++ b/SECURITY_REQUIREMENTS.md
@@ -1,0 +1,82 @@
+<!--
+SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: MIT
+-->
+
+# **Security Requirements and Expectations**
+
+This document outlines the **security requirements** for the `gh-bofh-rs` project, as well as what users can and cannot expect in terms of security from the software.
+
+---
+
+## **What Users Can Expect**
+
+1. **No Sensitive Data Handling**:
+   - The `gh-bofh-rs` software does not handle, process, or store any sensitive or personal data. It is a simple command-line tool that generates random BOFH excuses.
+   - Users can expect that the software does not pose a risk to their data privacy.
+
+2. **No Network Communication**:
+   - The software does not communicate over the network. All operations are performed locally on the user's machine.
+   - Users can expect that the software does not introduce network-related security risks.
+
+3. **Transparent Source Code**:
+   - The source code is open and available for review on GitHub. Users can inspect the code to verify its functionality and security.
+   - Users can expect transparency in how the software operates.
+
+4. **Minimal Dependencies**:
+   - The software has minimal dependencies (`clap` for CLI argument parsing and `rand` for random number generation). These dependencies are widely used and well-maintained.
+   - Users can expect that the software does not introduce unnecessary security risks through third-party libraries.
+
+---
+
+## **What Users Cannot Expect**
+
+1. **No Security Guarantees**:
+   - While the software is designed to be simple and secure, it is provided **as-is** without any explicit security guarantees.
+   - Users should not expect the software to be free from vulnerabilities or bugs.
+
+2. **No Protection Against Malicious Use**:
+   - The software does not include mechanisms to prevent misuse or malicious use. For example, it does not validate or sanitize input beyond basic CLI argument parsing.
+   - Users should not expect the software to protect against intentional misuse.
+
+3. **No Long-Term Support for Security Issues**:
+   - While security issues will be addressed on a best-effort basis, there is no formal long-term support (LTS) commitment for the software.
+   - Users should not expect ongoing security updates or patches beyond the maintainer's availability.
+
+---
+
+## **Security Requirements**
+
+The `gh-bofh-rs` software is intended to meet the following security requirements:
+
+1. **No Data Collection**:
+   - The software must not collect, store, or transmit any user data.
+
+2. **Local Execution Only**:
+   - The software must operate entirely locally on the user's machine, with no network communication.
+
+3. **Minimal Attack Surface**:
+   - The software must minimize its attack surface by using only essential dependencies and avoiding unnecessary complexity.
+
+4. **Transparency**:
+   - The software must provide full transparency into its functionality through open-source code and clear documentation.
+
+---
+
+## **Security Justification**
+
+The security requirements are justified based on the following principles:
+
+1. **Simplicity**:
+   - The software is designed to be simple and lightweight, reducing the likelihood of security vulnerabilities.
+
+2. **Limited Scope**:
+   - The software's scope is limited to generating random excuses, which does not involve sensitive operations or data.
+
+3. **Open Source**:
+   - The open-source nature of the software allows for community review and contributions, which helps identify and address potential security issues.
+
+4. **Minimal Dependencies**:
+   - By relying on well-established and widely-used libraries (`clap` and `rand`), the software reduces the risk of introducing vulnerabilities through third-party code.


### PR DESCRIPTION
### TL;DR

Updated project name to `gh-bofh-rs` and added a new security requirements document.

### What changed?

- Updated the project name from `gh-bofh` to `gh-bofh-rs` in the architecture documentation
- Fixed the architecture documentation link in README to use a relative path
- Added a new `SECURITY_REQUIREMENTS.md` document that outlines:
  - What users can expect (no sensitive data handling, no network communication, transparent code, minimal dependencies)
  - What users cannot expect (no security guarantees, no protection against misuse, no long-term support)
  - Security requirements (no data collection, local execution only, minimal attack surface, transparency)
  - Security justification based on simplicity, limited scope, open source, and minimal dependencies
- Added a reference to the new security document in the README

### How to test?

- Verify that all references to the project name are consistent
- Check that the links in the README correctly point to the architecture and security documents
- Review the security requirements document for completeness and accuracy

### Why make this change?

This change provides better documentation around security expectations and requirements for the project, which helps users understand what they can and cannot expect from a security perspective. The project name update ensures consistency across documentation, and the fixed links improve navigation within the repository.