### PR TITLE
build: update missing copyright years

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+# SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 #
 # SPDX-License-Identifier: CC0-1.0
 branches:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: MIT

--- a/benches/excuses_benchmark.rs
+++ b/benches/excuses_benchmark.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT

--- a/tests/test_binary_classic.rs
+++ b/tests/test_binary_classic.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT

--- a/tests/test_binary_modern.rs
+++ b/tests/test_binary_modern.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT

--- a/tests/test_common_excuses.rs
+++ b/tests/test_common_excuses.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT

--- a/tests/test_modern_excuses.rs
+++ b/tests/test_modern_excuses.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ali Sajid Imami
+// SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
 //
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT


### PR DESCRIPTION
### TL;DR

Updated copyright year range from 2022-2024 to 2023-2025 across all files.

### What changed?

Modified the SPDX-FileCopyrightText headers in multiple files to reflect a new copyright year range of 2023-2025, replacing the previous range of 2022-2024. This change affects:
- `.releaserc.yml`
- `GOVERNANCE.md`
- Benchmark files
- Test files

### How to test?

No functional testing is required as this is a documentation update. You can verify the changes by checking that all copyright headers now show the updated year range.

### Why make this change?

To ensure the copyright information is up-to-date and accurately reflects the current project timeline. This is part of regular maintenance to keep legal notices current.