### PR TITLE
docs: add a SECURITY_ASSURANCE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ The architecture documentation can be found in the project repository under the 
 The security requirements and expectations documentation can be found in the project repository under the following URL:  
 [Security Requirements Documentation](SECURITY_REQUIREMENTS.md)
 
+## Security Assurance Case
+
+The security assurance case document can be found in the project repository under the following URL:  
+[Security Assurance Case Documentation](SECURITY_ASSURANCE.md)
+
 ## License
 
 This project is dual-licensed under the [MIT](LICENSE-MIT) and [Apache 2.0](LICENSE-APACHE) licenses.

--- a/SECURITY_ASSURANCE.md
+++ b/SECURITY_ASSURANCE.md
@@ -1,0 +1,96 @@
+<!--
+SPDX-FileCopyrightText: 2023 - 2025 Ali Sajid Imami
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: MIT
+-->
+
+# **Assurance Case for gh-bofh**
+
+This document provides an assurance case for the `gh-bofh` project, justifying why its security requirements are met. The assurance case includes a description of the threat model, identification of trust boundaries, an argument that secure design principles have been applied, and an argument that common implementation security weaknesses have been countered.
+
+---
+
+## **1. Threat Model**
+
+### **Description of Threats**
+
+The `gh-bofh` project is a simple command-line tool that generates random BOFH excuses. Given its limited scope and functionality, the threat model is relatively simple. The primary threats include:
+
+1. **Unauthorized Access**:
+   - Threat: An attacker could attempt to modify the software or its dependencies to introduce malicious behavior.
+   - Mitigation: The software is distributed as open-source code, allowing users to inspect and verify its integrity. Dependencies are minimized and well-vetted.
+
+2. **Data Privacy Risks**:
+   - Threat: The software could inadvertently collect or expose sensitive user data.
+   - Mitigation: The software does not collect, store, or transmit any user data. All operations are performed locally on the user's machine.
+
+3. **Code Injection**:
+   - Threat: An attacker could attempt to inject malicious code into the software or its dependencies.
+   - Mitigation: The software uses minimal dependencies (`clap` and `rand`), which are widely used and well-maintained. Input validation is performed by the `clap` library.
+
+---
+
+## **2. Trust Boundaries**
+
+### **Identification of Trust Boundaries**
+
+The trust boundaries for the `gh-bofh` project are as follows:
+
+1. **User Input**:
+   - The command-line arguments provided by the user are parsed by the `clap` library. This is the primary trust boundary, as user input is the only external data the software processes.
+
+2. **Dependencies**:
+   - The software relies on two external libraries (`clap` and `rand`). These libraries are trusted components, but their integrity is ensured by using verified versions from the Rust ecosystem.
+
+3. **Local Execution**:
+   - The software operates entirely locally on the user's machine. There is no network communication or external data exchange, which eliminates many potential trust boundaries.
+
+---
+
+## **3. Secure Design Principles**
+
+### **Argument for Secure Design Principles**
+
+The `gh-bofh` project adheres to the following secure design principles:
+
+1. **Minimal Attack Surface**:
+   - The software has a minimal attack surface due to its limited functionality and lack of network communication. This reduces the potential for security vulnerabilities.
+
+2. **Least Privilege**:
+   - The software does not require elevated privileges to run. It operates with the same permissions as the user running the command.
+
+3. **Transparency**:
+   - The software is open-source, allowing users to inspect the code and verify its security. This transparency helps build trust and enables community review.
+
+4. **Defense in Depth**:
+   - Although the software is simple, it uses well-established libraries (`clap` and `rand`) that follow secure coding practices. This provides an additional layer of security.
+
+---
+
+## **4. Countering Common Implementation Security Weaknesses**
+
+### **Argument for Countering Common Weaknesses**
+
+The `gh-bofh` project addresses common implementation security weaknesses as follows:
+
+1. **Input Validation**:
+   - The `clap` library is used to parse and validate command-line arguments, preventing injection attacks or malformed input.
+
+2. **Memory Safety**:
+   - The software is written in Rust, a memory-safe language that prevents common vulnerabilities such as buffer overflows and use-after-free errors.
+
+3. **Dependency Management**:
+   - The software uses minimal dependencies, and these dependencies are regularly updated to their latest secure versions using tools like `cargo-audit`.
+
+4. **No Sensitive Data Handling**:
+   - The software does not handle sensitive data, eliminating risks related to data breaches or leaks.
+
+5. **Local Execution**:
+   - The software operates entirely locally, reducing the risk of network-based attacks such as man-in-the-middle (MITM) or remote code execution.
+
+---
+
+## **5. Conclusion**
+
+The `gh-bofh` project meets its security requirements by adhering to secure design principles, minimizing its attack surface, and countering common implementation security weaknesses. The threat model is simple due to the software's limited scope, and trust boundaries are clearly defined. The use of memory-safe languages, minimal dependencies, and open-source transparency further strengthens the security of the project.


### PR DESCRIPTION
### TL;DR

Added a Security Assurance Case document and updated README to reference it.

### What changed?

- Created a new `SECURITY_ASSURANCE.md` document that provides a comprehensive security assurance case for the gh-bofh project
- Added a section to the README.md that links to the new Security Assurance Case documentation

The security assurance document includes:
- A threat model with description of potential threats and mitigations
- Identification of trust boundaries
- Arguments for secure design principles implementation
- Explanation of how common security weaknesses are countered
- A conclusion summarizing the security posture of the project

### How to test?

- Verify the new link in the README.md works correctly
- Review the content of the SECURITY_ASSURANCE.md file to ensure it accurately represents the security posture of the project

### Why make this change?

This change enhances the project documentation by providing a formal security assurance case that demonstrates how the project meets its security requirements. It helps users and contributors understand the security considerations that have been made during development and provides transparency about the project's security posture.