### PR TITLE
ci: update permissions

### DIFF
--- a/.github/workflows/get_next_version.yaml
+++ b/.github/workflows/get_next_version.yaml
@@ -10,8 +10,7 @@ on:
             new-release-published:
                 description: Indicates whether a new release will be published. The value is a string, either 'true' or 'false'.
                 value: ${{ jobs.get-next-version.outputs.new-release-published }}
-permissions:
-    contents: read
+
 jobs:
     get-next-version:
         name: Get next release version


### PR DESCRIPTION
### TL;DR

Removed the `permissions: contents: read` section from the get_next_version workflow.

### What changed?

This PR removes the explicit permissions declaration that was restricting the workflow to read-only access to repository contents. By removing this constraint, the workflow will now use the default permissions assigned to the GitHub token.

### How to test?

1. Trigger the get_next_version workflow manually or through a workflow dispatch
2. Verify that the workflow completes successfully
3. Confirm that any actions requiring more than read-only permissions now work properly

### Why make this change?

The read-only permission restriction was likely preventing the workflow from performing necessary operations. By removing this constraint, the workflow can now utilize the default permissions, which may be required for certain actions like determining the next version or publishing release information.