### PR TITLE
ci: fix the code coverage generator

### DIFF
--- a/.github/workflows/code_coverage.yaml
+++ b/.github/workflows/code_coverage.yaml
@@ -23,6 +23,7 @@ jobs:
             # Nightly Rust is required for cargo llvm-cov --doc.
             - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # nightly
               with:
+                toolchain: nightly
                 components: llvm-tools-preview
             - uses: taiki-e/install-action@351cce3d3afa3dbd66bbe6d30df1d481b1448522 # v2.49.32
               with:


### PR DESCRIPTION
### TL;DR

Fix the GitHub Actions code coverage workflow by explicitly specifying the nightly toolchain.

### What changed?

Added the explicit `toolchain: nightly` parameter to the Rust toolchain setup in the code coverage workflow. Previously, the workflow was using the `dtolnay/rust-toolchain` action but didn't explicitly specify the toolchain version.

### How to test?

Run the code coverage GitHub Action workflow to verify it properly installs the nightly toolchain and successfully completes the code coverage analysis.

### Why make this change?

The workflow requires the nightly Rust toolchain for `cargo llvm-cov --doc` to function correctly, as noted in the comment. Without explicitly specifying `toolchain: nightly`, the action might not use the correct toolchain version, potentially causing the coverage analysis to fail.